### PR TITLE
Stop using reserved JavaScript keyword `package`

### DIFF
--- a/src/components/Overlay.js
+++ b/src/components/Overlay.js
@@ -101,10 +101,10 @@ export default class OverlayComponent extends Component {
 
     // TODO: Change to ES6 import syntax
     const resolve = require('path').resolve
-    const package = atom.packages.getLoadedPackage('quicknote')
-    if (!package)
+    const pack = atom.packages.getLoadedPackage('quicknote')
+    if (!pack)
       return null
-    const {path} = package
+    const {path} = pack
     const localPath = 'resources/trinitynote-vector.svg'
     const iconPath = (path) ? resolve(`${path}/${localPath}`) : ''
 


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!